### PR TITLE
feat(session): implement /session endpoint with HTTP-only cookie

### DIFF
--- a/src/main/java/ua/cn/stu/pixelbattle/config/SecurityConfig.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package ua.cn.stu.pixelbattle.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,6 +29,7 @@ public class SecurityConfig {
   private static final String[] PUBLIC_URLS = {
       "/swagger-ui/**",
       "/api/v1/auth/register",
+      "/api/v1/session",
       "/api/v1/auth/login",
       "/api/v1/auth/refresh",
       "/api/v1/actuator/health",
@@ -77,8 +79,16 @@ public class SecurityConfig {
             .requestMatchers(PROTECTED_URLS).authenticated()
             .anyRequest().authenticated()
         )
-        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(ex -> ex
+            .authenticationEntryPoint((req, res, authEx) -> {
+              res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+              res.setContentType("application/json");
+              res.getWriter().write(
+                  "{\"error\":\"Unauthorized\",\"message\":\"Access token missing or invalid\"}"
+              );
+            })
+        );
     return http.build();
   }
 

--- a/src/main/java/ua/cn/stu/pixelbattle/config/WebConfigDev.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/config/WebConfigDev.java
@@ -6,20 +6,18 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
- * Web configuration class that customizes MVC settings.
- *
- * <p>Specifically, it configures Cross-Origin Resource Sharing (CORS)
- * to allow requests from all origins and standard HTTP methods.
+ * CORS configuration for development (Postman / local testing).
+ * Allows all origins and methods without credentials.
  */
 @Configuration
-@Profile("prod")
-public class WebConfig implements WebMvcConfigurer {
+@Profile("dev")
+public class WebConfigDev implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOriginPatterns("https://pixel-battle.zebaro.dev")
-        .allowedMethods("GET", "POST", "PUT", "DELETE")
+        .allowedOriginPatterns("*")
+        .allowedMethods("*")
         .allowedHeaders("*")
-        .allowCredentials(true);
+        .allowCredentials(false);
   }
 }

--- a/src/main/java/ua/cn/stu/pixelbattle/controller/AuthController.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/controller/AuthController.java
@@ -1,69 +1,145 @@
 package ua.cn.stu.pixelbattle.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import ua.cn.stu.pixelbattle.dto.AuthRequest;
 import ua.cn.stu.pixelbattle.dto.AuthResponse;
 import ua.cn.stu.pixelbattle.dto.RegisterRequest;
 import ua.cn.stu.pixelbattle.service.AuthService;
 
+import java.time.Duration;
+
 
 /**
  * Controller for authentication endpoints.
  *
- * <p>Provides APIs for user registration, login, and refreshing JWT tokens.
+ * <p>Provides APIs for user registration, login,  refreshing and logut JWT tokens.
  */
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
   private final AuthService authService;
+  private static final String REFRESH_COOKIE_NAME = "refreshToken";
+  private static final Duration REFRESH_TOKEN_AGE = Duration.ofDays(7);
 
   /**
-   * Registers a new user and returns authentication tokens.
+   * Registers a new user and immediately logs them in.
    *
-   * @param req registration request containing username and password
-   * @return AuthResponse containing access and refresh tokens
+   * <p>The access token is returned in the response body, and the refresh token
+   * is stored as an HTTP-only cookie.</p>
+   *
+   * @param req the registration request containing {@code username} and {@code password}
+   * @param response the {@link HttpServletResponse} used to add the refresh token cookie
+   * @return a {@link ResponseEntity} containing the access token in {@link AuthResponse}
+   *         and HTTP status 201 CREATED
    */
   @PostMapping("/register")
-  public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest req) {
+  public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest req, HttpServletResponse response) {
     authService.register(req);
 
     AuthRequest authRequest = new AuthRequest(req.getUsername(), req.getPassword());
     AuthResponse authResponse = authService.login(authRequest);
 
-    return ResponseEntity.status(HttpStatus.CREATED).body(authResponse);
+    addRefreshCookie(response, authResponse.getRefreshToken());
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(new AuthResponse(authResponse.getToken()));
   }
 
   /**
-   * Authenticates a user and returns JWT tokens.
+   * Authenticates an existing user.
    *
-   * @param req login request containing username and password
-   * @return AuthResponse containing access and refresh tokens
+   * <p>The access token is returned in the response body, and the refresh token
+   * is stored as an HTTP-only cookie.</p>
+   *
+   * @param req the login request containing {@code username} and {@code password}
+   * @param response the {@link HttpServletResponse} used to add the refresh token cookie
+   * @return a {@link ResponseEntity} containing the access token in {@link AuthResponse}
+   *         and HTTP status 200 OK
    */
   @PostMapping("/login")
-  public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest req) {
+  public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest req, HttpServletResponse response) {
     AuthResponse authResponse = authService.login(req);
-    return ResponseEntity.status(HttpStatus.OK).body(authResponse);
+    addRefreshCookie(response, authResponse.getRefreshToken());
+
+    return ResponseEntity.ok(new AuthResponse(authResponse.getToken()));
   }
 
   /**
-   * Refreshes the access token using a valid refresh token.
+   * Refreshes the access token using the refresh token stored in an HTTP-only cookie.
    *
-   * @param refreshTokenStr the refresh token string
-   * @return AuthResponse containing a new access token and refresh token
+   * <p>If the refresh token is missing or invalid, returns HTTP status 401 Unauthorized.
+   * Otherwise, a new access token is returned in the response body and the refresh
+   * token is updated in the cookie.</p>
+   *
+   * @param refreshToken the value of the refresh token cookie (optional)
+   * @param response the {@link HttpServletResponse} used to update the refresh token cookie
+   * @return a {@link ResponseEntity} containing the new access token in {@link AuthResponse}
+   *         or HTTP status 401 if unauthorized
    */
   @PostMapping("/refresh")
-  public ResponseEntity<AuthResponse> refreshToken(@RequestBody String refreshTokenStr) {
-    AuthResponse authResponse = authService.refreshToken(refreshTokenStr);
-    return ResponseEntity.ok(authResponse);
+  public ResponseEntity<AuthResponse> refreshToken(@CookieValue(value = REFRESH_COOKIE_NAME, required = false) String refreshToken,
+                                                   HttpServletResponse response) {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    AuthResponse authResponse = authService.refreshToken(refreshToken);
+
+    addRefreshCookie(response, authResponse.getRefreshToken());
+
+    return ResponseEntity.ok(new AuthResponse(authResponse.getToken()));
   }
 
+  /**
+   * Logs out the current user by deleting the refresh token.
+   *
+   * <p>The refresh token cookie is cleared on the client, effectively ending the session.</p>
+   *
+   * @param refreshToken the value of the refresh token cookie (optional)
+   * @param response the {@link HttpServletResponse} used to clear the cookie
+   * @return a {@link ResponseEntity} with HTTP status 200 OK
+   */
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(@CookieValue(value = REFRESH_COOKIE_NAME, required = false) String refreshToken,
+                                     HttpServletResponse response) {
+    authService.logout(refreshToken);
 
+    ResponseCookie deleteCookie = ResponseCookie.from(REFRESH_COOKIE_NAME, "")
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .maxAge(0)
+        .sameSite("Lax")
+        .build();
+
+    response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * Adds or updates the HTTP-only refresh token cookie for the client.
+   *
+   * <p>The cookie is used to refresh access tokens without requiring
+   * the user to log in again.</p>
+   *
+   * @param response the {@link HttpServletResponse} used to add the cookie
+   * @param refreshToken the refresh token value
+   */
+  private void addRefreshCookie(HttpServletResponse response, String refreshToken) {
+    ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
+        .httpOnly(true)
+        .secure(true) // in prod must be true?
+        .path("/")
+        .maxAge(REFRESH_TOKEN_AGE)
+        .sameSite("Lax")
+        .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
 }

--- a/src/main/java/ua/cn/stu/pixelbattle/controller/SessionController.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/controller/SessionController.java
@@ -1,0 +1,50 @@
+package ua.cn.stu.pixelbattle.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ua.cn.stu.pixelbattle.dto.UserSessionResponse;
+import ua.cn.stu.pixelbattle.service.SessionService;
+
+/**
+ * REST controller for managing the current user session.
+ *
+ * <p>The {@code /session} endpoint allows the frontend to check if a user is
+ * logged in using an HTTP-only refresh token. Returns minimal user information
+ * (id and username) if the session is valid.
+ */
+@RestController
+@RequestMapping(("/api/v1"))
+@AllArgsConstructor
+public class SessionController {
+
+  private final SessionService sessionService;
+
+  /**
+   * Retrieves the current user's session information.
+   *
+   * <p>This method checks the refresh token from the HTTP-only cookie. If the token is valid,
+   * it returns a {@link UserSessionResponse} containing the user's id and username.
+   * If the session is invalid or the user is not found, it returns a 401 Unauthorized status.</p>
+   *
+   * @param request the {@link HttpServletRequest} containing cookies
+   * @return a {@link ResponseEntity} with {@link UserSessionResponse} or 401 status
+   */
+  @GetMapping("/session")
+  public ResponseEntity<UserSessionResponse> getSession(HttpServletRequest request) {
+    try {
+      UserSessionResponse response = sessionService.getSessionResponse(request);
+      if (response == null) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      return ResponseEntity.ok(response);
+    } catch (Exception ex) {
+      // service may throw when token invalid/expired — treat as unauthorized
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+  }
+}

--- a/src/main/java/ua/cn/stu/pixelbattle/dto/UserSessionResponse.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/dto/UserSessionResponse.java
@@ -1,0 +1,20 @@
+package ua.cn.stu.pixelbattle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object for returning basic user session information.
+ *
+ * <p>This DTO is used by the {@code /session} endpoint to provide minimal
+ * details about the currently logged-in user.
+ * </p>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSessionResponse {
+  private Long id;
+  private String username;
+}

--- a/src/main/java/ua/cn/stu/pixelbattle/security/JwtAuthenticationFilter.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/security/JwtAuthenticationFilter.java
@@ -44,17 +44,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     String header = req.getHeader("Authorization");
     if (header != null && header.startsWith("Bearer ")) {
       String token = header.substring(7);
-      if (jwtTokenService.validateToken(token)) {
-        Long userId = jwtTokenService.getUserId(token);
-        CustomUserDetails userDetails = jwtTokenService.loadUserById(userId);
-        UsernamePasswordAuthenticationToken auth =
-            new UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
+      try {
+        if (jwtTokenService.validateToken(token)) {
+          Long userId = jwtTokenService.getUserId(token);
+          CustomUserDetails userDetails = jwtTokenService.loadUserById(userId);
+          UsernamePasswordAuthenticationToken auth =
+              new UsernamePasswordAuthenticationToken(
+                  userDetails,
+                  null,
+                  userDetails.getAuthorities());
+
+          SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+      }catch (Exception ex) {
+        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        res.setContentType("application/json");
+        res.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"Access token expired or invalid\"}");
+        return;
       }
     }
+
     chain.doFilter(req, res);
   }
 

--- a/src/main/java/ua/cn/stu/pixelbattle/service/AuthService.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/service/AuthService.java
@@ -93,4 +93,15 @@ public class AuthService {
 
     return new AuthResponse(newAccessToken, newRefreshToken);
   }
+
+  /**
+   * Logs out a user by invalidating the provided refresh token.
+   *
+   * @param refreshTokenStr the refresh token to delete; may be null or blank
+   */
+  public void logout(String refreshTokenStr) {
+    if (refreshTokenStr != null && !refreshTokenStr.isBlank()) {
+      refreshTokenService.deleteByToken(refreshTokenStr);
+    }
+  }
 }

--- a/src/main/java/ua/cn/stu/pixelbattle/service/SessionService.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/service/SessionService.java
@@ -1,0 +1,70 @@
+package ua.cn.stu.pixelbattle.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import ua.cn.stu.pixelbattle.dto.UserSessionResponse;
+import ua.cn.stu.pixelbattle.model.User;
+
+/**
+ * Service for handling user session logic.
+ *
+ * <p>Responsible for validating HTTP-only refresh tokens from cookies
+ * and retrieving minimal user information for the frontend.
+ */
+@Service
+@AllArgsConstructor
+public class SessionService {
+
+  private final RefreshTokenService refreshTokenService;
+  private final UserService userService;
+
+  /**
+   * Checks the current user's session based on the refresh token cookie
+   * and returns a minimal {@link UserSessionResponse} if the session is valid.
+   *
+   * <p>This method performs the following steps:
+   * <ol>
+   *   <li>Retrieves cookies from the {@link HttpServletRequest}.</li>
+   *   <li>Extracts the "refreshToken" cookie.</li>
+   *   <li>Validates the refresh token using {@link RefreshTokenService}.</li>
+   *   <li>Fetches the corresponding {@link User} from the database.</li>
+   *   <li>If valid, returns a {@link UserSessionResponse} containing
+   *       the user's id and username.</li>
+   *   <li>If any step fails, returns {@code null}.</li>
+   * </ol>
+   *
+   * @param request the {@link HttpServletRequest} containing cookies
+   * @return a {@link UserSessionResponse} if the session is valid; {@code null} otherwise
+   */
+  public UserSessionResponse getSessionResponse(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+
+    String refreshToken = null;
+    for (Cookie cookie : cookies) {
+      if ("refreshToken".equals(cookie.getName())) {
+        refreshToken = cookie.getValue();
+        break;
+      }
+    }
+    if (refreshToken == null) {
+      return null;
+    }
+
+    Long userId = refreshTokenService.verifyExpiration(refreshToken);
+    if (userId == null) {
+      return null;
+    }
+
+    User user = userService.getUserById(userId).orElse(null);
+    if (user == null) {
+      return null;
+    }
+
+    return new UserSessionResponse(user.getId(), user.getUsername());
+  }
+}

--- a/src/main/java/ua/cn/stu/pixelbattle/service/UserService.java
+++ b/src/main/java/ua/cn/stu/pixelbattle/service/UserService.java
@@ -1,0 +1,42 @@
+package ua.cn.stu.pixelbattle.service;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import ua.cn.stu.pixelbattle.model.User;
+import ua.cn.stu.pixelbattle.repository.UserRepository;
+
+/**
+ * Service for managing {@link User} entities.
+ *
+ * <p>Provides methods to retrieve users by their unique identifier or username.
+ * All methods return {@link Optional} to safely handle the case when a user
+ * does not exist in the database.
+ */
+@Service
+@AllArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  /**
+   * Retrieves a user by their unique ID.
+   *
+   * @param id the unique identifier of the user
+   * @return an {@link Optional} containing the {@link User} if found, or empty if not
+   */
+  public Optional<User> getUserById(Long id) {
+    return userRepository.findById(id);
+  }
+
+  /**
+   * Retrieves a user by their username.
+   *
+   * @param username the username of the user
+   * @return an {@link Optional} containing the {@link User} if found, or empty if not
+   */
+  public Optional<User> getUserByUsername(String username) {
+    return userRepository.findByUsername(username);
+  }
+
+}


### PR DESCRIPTION
- Added /session endpoint to check current user session via refresh token cookie
- Returns user info (id, username) if session is valid
- Returns 401 Unauthorized if session is invalid or expired
- Supports CORS and fetch with credentials: 'include'
- Minor fixes for consistent error handling
- Access token validation now triggers 401 instead of 403